### PR TITLE
States and logic processing to handle Create and Delete kc

### DIFF
--- a/assets/test-cluster.yaml
+++ b/assets/test-cluster.yaml
@@ -7,6 +7,9 @@ spec:
   customerID: myCustomerID
   cloudProvider:
     name: aws
+    credentials:
+      username: cindyo
+      password: fakepassword1
   provisioner:
     name: juju
   cluster:

--- a/pkg/apis/clustercontroller/v1alpha1/types.go
+++ b/pkg/apis/clustercontroller/v1alpha1/types.go
@@ -31,7 +31,7 @@ const (
 )
 
 type CloudProviderInfo struct {
-	Name        string                   `json:"name"`
+	Name        CloudProviderName        `json:"name"`
 	Credentials CloudProviderCredentials `json:"credentials,omitempty"`
 }
 
@@ -65,8 +65,20 @@ type KrakenClusterSpec struct {
 	Cluster       ClusterInfo       `json:"cluster"`
 }
 
+type KrakenClusterState string
+
+const (
+	Unknown  KrakenClusterState = ""
+	Creating KrakenClusterState = "Creating"
+	Created  KrakenClusterState = "Created"
+	Deleting KrakenClusterState = "Deleting"
+	Deleted  KrakenClusterState = "Deleted"
+)
+
 type KrakenClusterStatus struct {
-	Status string `json:"status"`
+	Status     string             `json:"status"`
+	State      KrakenClusterState `json:"state"`
+	Kubeconfig string             `json:"kubeconfig"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Used the finalizer for the delete case which works well. (I found that deleting the resource via 'kubectl delete kc my-test-cluster' deletes the resource before we can process it in the worker, so use of the finalizer seemed the best option).  Jordan Liggitt says the deletionGracePeriodSeconds only applies to pods.